### PR TITLE
Fix keep size api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # web interface to run cellpose
 
-[![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?plugin=https://cellpose.org)
+[![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?plugin=https://cellpose.org) [![open in ImageJ.JS](https://ij.imjoy.io/assets/badge/open-in-imagej-js-badge.svg)](https://ij.imjoy.io/)
 
 If you'd like to run it on your local computer, run
 ~~~
@@ -41,7 +41,5 @@ Basically, you will be able to show an the cellpose window and call `segment` fu
     print(result["mask"])
 ```
 
-You can find a live demo [here](https://ij.imjoy.io/?plugin=https://gist.github.com/oeway/c9592f23c7ee147085f0504d2f3e993a) with its [source code in Javascript](https://gist.github.com/oeway/c9592f23c7ee147085f0504d2f3e993a). For Python, [here](https://gist.github.com/oeway/cec7b38e0a8fcda294de5362c07072f0) is an example notebook.
-
-
+CellPose is also integrated with ImageJ.JS, you can [![launch ImageJ.JS](https://ij.imjoy.io/assets/badge/launch-imagej-js-badge.svg)](https://ij.imjoy.io), then run it by clicking "Segment with CellPose" in the plugin menu. The source code of the plugin(in JavaScript) is [here](https://gist.github.com/oeway/c9592f23c7ee147085f0504d2f3e993a). For Python, [here](https://gist.github.com/oeway/cec7b38e0a8fcda294de5362c07072f0) is an example notebook.
 


### PR DESCRIPTION
We forgot to also change the keep_size implementation for the imjoy api (swap the height and width for cv2.resize). This is a fix for it.

The following screenshot shows the issue of swapped height and width:
<img width="1308" alt="Screenshot 2020-11-03 at 18 38 56" src="https://user-images.githubusercontent.com/478667/98020892-e3c4e900-1e03-11eb-8e1d-27fff19100b9.png">


Since now CellPose is shipped as a default plugin for ImageJ.JS, I also improved the readme by adding a badge I just created.