### PR TITLE
Fix localStorage error in incognito window

### DIFF
--- a/static/imjoyAPI.js
+++ b/static/imjoyAPI.js
@@ -150,7 +150,12 @@ document.addEventListener('DOMContentLoaded', function(){
                 invert: document.getElementById("invert").checked,
                 keep_size: document.getElementById("keep-size").checked,
               }
-              saveConfig(config);
+              try {
+                saveConfig(config);
+              }
+              catch(e){
+                console.error(e);
+              }
               resolve(config)
               api.close();
             }


### PR DESCRIPTION
When using cellpose in an incognito window, the browser blocks access to localstorage and complaining the following error: 
```
DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
    at https://www.cellpose.org/static/imjoyAPI.js?20200915f:118:32
    at new Promise (<anonymous>)
    at Object.showConfig (https://www.cellpose.org/static/imjoyAPI.js?20200915f:112:18)
    at https://cdn.jsdelivr.net/npm/imjoy-rpc@latest/dist/imjoy-rpc.min.js:1:7105
```

This is a fix to allow save settings to fail.